### PR TITLE
Pin Docker images to specific versions for stability; remove Huntarr

### DIFF
--- a/container-config/huntarr.caddy
+++ b/container-config/huntarr.caddy
@@ -1,4 +1,0 @@
-@huntarr host huntarr.{env.DOMAIN}
-handle @huntarr {
-    reverse_proxy http://huntarr:9705
-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   pihole:
     container_name: pihole
-    image: pihole/pihole:latest
+    image: pihole/pihole:2025.11.1
     ports:
       - "53:53/tcp"
       - "53:53/udp"
@@ -36,7 +36,7 @@ services:
 
   jellyfin:
     container_name: jellyfin
-    image: jellyfin/jellyfin:latest
+    image: jellyfin/jellyfin:10.11.6
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - ${DATA_ROOT}:/data
@@ -69,7 +69,7 @@ services:
       - homepage.widget.key=${JELLYFIN_API_KEY}
   
   sonarr:
-    image: lscr.io/linuxserver/sonarr
+    image: lscr.io/linuxserver/sonarr:4.0.16
     container_name: sonarr
     environment:
       - PUID=${USER_ID}
@@ -101,7 +101,7 @@ services:
       - homepage.widget.key=${SONARR_API_KEY}
 
   radarr:
-    image: lscr.io/linuxserver/radarr
+    image: lscr.io/linuxserver/radarr:6.0.4
     container_name: radarr
     environment:
       - PUID=${USER_ID}
@@ -133,7 +133,7 @@ services:
       - homepage.widget.key=${RADARR_API_KEY}
 
   lidarr:
-    image: lscr.io/linuxserver/lidarr
+    image: lscr.io/linuxserver/lidarr:3.1.0
     container_name: lidarr
     environment:
       - PUID=${USER_ID}
@@ -165,7 +165,7 @@ services:
       - homepage.widget.key=${LIDARR_API_KEY}
 
   bazarr:
-    image: lscr.io/linuxserver/bazarr
+    image: lscr.io/linuxserver/bazarr:1.5.5
     container_name: bazarr
     environment:
       - PUID=${USER_ID}
@@ -197,7 +197,7 @@ services:
       - homepage.widget.key=${BAZARR_API_KEY}
 
   jellyseerr:
-    image: fallenbagel/jellyseerr:latest
+    image: fallenbagel/jellyseerr:2.7.3
     container_name: jellyseerr
     environment:
       - LOG_LEVEL=debug
@@ -221,7 +221,7 @@ services:
       - homepage.widget.key=${JELLYSEERR_API_KEY}
 
   prowlarr:
-    image: lscr.io/linuxserver/prowlarr:latest
+    image: lscr.io/linuxserver/prowlarr:2.3.0
     container_name: prowlarr
     environment:
       - PUID=${USER_ID}
@@ -252,7 +252,7 @@ services:
       - homepage.widget.key=${PROWLARR_API_KEY}
   
   kiwix:
-    image: ghcr.io/kiwix/kiwix-serve:latest
+    image: ghcr.io/kiwix/kiwix-serve:3.8.1
     container_name: kiwix
     volumes:
       - ${DATA_ROOT}/media/zim:/data
@@ -262,7 +262,7 @@ services:
       - kiwix
 
   flaresolverr:
-    image: ghcr.io/flaresolverr/flaresolverr:latest
+    image: ghcr.io/flaresolverr/flaresolverr:v3.4.6
     container_name: flaresolverr
     restart: always
     network_mode: "service:vpn"
@@ -278,7 +278,7 @@ services:
       - TZ=${TIMEZONE}
 
   qbittorrent:
-    image: lscr.io/linuxserver/qbittorrent:libtorrentv1
+    image: lscr.io/linuxserver/qbittorrent:5.1.4-libtorrentv1
     container_name: qbittorrent
     environment:
       - PUID=${USER_ID}
@@ -313,7 +313,7 @@ services:
       - homepage.widget.password=${QBITTORRENT_PASSWORD}
 
   vpn:
-    image: thrnz/docker-wireguard-pia
+    image: thrnz/docker-wireguard-pia:20260201_master_eb24c58
     container_name: vpn
     volumes:
       - ${CONFIG_ROOT:-.}/pia:/pia
@@ -340,8 +340,9 @@ services:
       timeout: 10s
       retries: 3
     restart: always
+
   unpackerr:
-    image: golift/unpackerr
+    image: golift/unpackerr:0.14
     container_name: unpackerr
     volumes:
       - ${DOWNLOAD_ROOT}:/data/torrents
@@ -359,7 +360,7 @@ services:
       - no-new-privileges:true
 
   homepage:
-    image: ghcr.io/gethomepage/homepage:latest
+    image: ghcr.io/gethomepage/homepage:v1.10
     container_name: homepage
     environment:
       - HOMEPAGE_ALLOWED_HOSTS=${HOMEPAGE_ALLOWED_HOSTS}
@@ -383,7 +384,7 @@ services:
     command: [sh, -c, "cp -n /app/config/tpl/*.yaml /app/config && node server.js"]
 
   caddy:
-    image: slothcroissant/caddy-cloudflaredns:latest
+    image: slothcroissant/caddy-cloudflaredns:2.10.2
     container_name: caddy
     restart: unless-stopped
     security_opt:
@@ -405,7 +406,7 @@ services:
         condition: service_started
   
   cleanuparr:
-    image: ghcr.io/cleanuparr/cleanuparr:latest
+    image: ghcr.io/cleanuparr/cleanuparr:2.5.1
     container_name: cleanuparr 
     restart: always
     volumes:
@@ -417,19 +418,8 @@ services:
       - PGID=${GROUP_ID}
       - PORT=11011
 
-  huntarr:
-    image: huntarr/huntarr:latest
-    container_name: huntarr
-    restart: always
-    ports:
-      - "9705:9705"
-    volumes:
-      - ${CONFIG_ROOT:-.}/huntarr:/config
-    environment:
-      - TZ=${TIMEZONE}
-
   autoheal:
-    image: willfarrell/autoheal:latest
+    image: willfarrell/autoheal:1.2.0
     container_name: autoheal
     restart: always
     environment:

--- a/homepage/tpl/bookmarks.yaml
+++ b/homepage/tpl/bookmarks.yaml
@@ -9,6 +9,3 @@
     - Cleanuparr:
         - icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/cleanuperr.svg
           href: https://cleanuparr.{{HOMEPAGE_VAR_DOMAIN}}
-    - Huntarr:
-        - icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/huntarr.png
-          href: https://huntarr.{{HOMEPAGE_VAR_DOMAIN}}

--- a/renovate.json
+++ b/renovate.json
@@ -8,9 +8,7 @@
     "docker-compose"
   ],
   "timezone": "America/Los_Angeles",
-  "schedule": [
-    "before 5am on Sunday"
-  ],
+  "schedule": ["0 8-20 * * 0,5,6"],
   "pinDigests": true,
   "prConcurrentLimit": 5,
   "packageRules": [


### PR DESCRIPTION
This PR sets pinned versions for Docker images (rather than using the latest tag). The goal is to increase stability and security.

This PR also removes Huntarr. I have not personally found it to be useful in my setup, and I see no reason to continue including it here.